### PR TITLE
Don't pass `shouldAutoFocus` to <input />

### DIFF
--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -75,6 +75,7 @@ class SingleOtpInput extends PureComponent<*> {
       errorStyle,
       focusStyle,
       disabledStyle,
+      shouldAutoFocus,
       ...rest
     } = this.props;
 


### PR DESCRIPTION
When passing custom props to HTML components React will throw a warning that says it doesn't recognize this prop. Since the prop is camel-cased (`shouldAutoFocus`), as opposed to lower-case (`shouldautofocus`), React tries to recognize it instead of just pass it to the DOM element.
The solution is the deconstructure it along with the used props so it won't get passed in `{...rest}`.