### PR TITLE
Handles number OTP input starting with zeroes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ export default class App extends Component {
   </tr>
   <tr>
     <td>value</td>
-    <td>string / number</td>
+    <td>string</td>
     <td><strong>true</strong></td>
     <td>''</td>
     <td>The value of the otp passed into the component.</td>

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -131,15 +131,13 @@ class OtpInput extends Component<Props, State> {
     activeInput: 0,
   };
 
-  getOtpValue = () => (
-    this.props.value ? this.props.value.toString().split('') : []
-  );
+  getOtpValue = () => this.props.value.split('');
 
   // Helper to return OTP from input
   handleOtpChange = (otp: string[]) => {
-    const { onChange, isInputNum } = this.props;
+    const { onChange } = this.props;
     const otpValue = otp.join('');
-    onChange(isInputNum ? Number(otpValue) : otpValue);
+    onChange(otpValue);
   };
 
   // Focus on input by index


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
      - Handle `OTP` input starting with `zeroes` when `isInputNum` prop is `true`. For instance `0123`
      - Fix for raised issue https://github.com/devfolioco/react-otp-input/issues/25

- **Any background context you want to provide?**
     - Deal with string value for both number and character inputs, otherwise there will be complexity in code while parsing Number inputs, since when we do `Number("0002")` it just returns `2` and we don't want this to happen. 

- **Screenshots and/or Live Demo**
    - Run demo https://devfolioco.github.io/react-otp-input/ with `isInputNum checked` and then enter OTP starting with `0s`

