### PR TITLE
update license to include 2019

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 Ajay NS
+Copyright (c) 2018 - 2019 Ajay NS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -56,21 +56,21 @@ export default class App extends Component {
   <tr>
     <td>numInputs</td>
     <td>number</td>
-    <td>true</td>
+    <td><strong>true</strong></td>
     <td>4</td>
     <td>Number of OTP inputs to be rendered.</td>
   </tr>
   <tr>
     <td>onChange</td>
     <td>function</td>
-    <td>true</td>
+    <td><strong>true</strong></td>
     <td>console.log</td>
     <td>Returns OTP code typed in inputs.</td>
   </tr>
   <tr>
     <td>value</td>
     <td>string / number</td>
-    <td>true</td>
+    <td><strong>true</strong></td>
     <td>''</td>
     <td>The value of the otp passed into the component.</td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -56,21 +56,21 @@ export default class App extends Component {
   <tr>
     <td>numInputs</td>
     <td>number</td>
-    <td><strong>true</strong></td>
+    <td>true</td>
     <td>4</td>
     <td>Number of OTP inputs to be rendered.</td>
   </tr>
   <tr>
     <td>onChange</td>
     <td>function</td>
-    <td><strong>true</strong></td>
+    <td>true</td>
     <td>console.log</td>
     <td>Returns OTP code typed in inputs.</td>
   </tr>
   <tr>
     <td>value</td>
     <td>string / number</td>
-    <td><strong>true</strong></td>
+    <td>true</td>
     <td>''</td>
     <td>The value of the otp passed into the component.</td>
   </tr>


### PR DESCRIPTION
update license to include 2019 as license valid time. Shall raise an issue to fix this as it can be easily overlooked and a permanent solution needs to be done.

<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
update the license to include 2019 as covered year too
- **Any background context you want to provide?**

- **Screenshots and/or Live Demo**
