### PR TITLE
Demo-site : Minor css and html changes

### DIFF
--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -58,6 +58,7 @@ class Demo extends Component {
                 type="number"
                 value={numInputs}
                 onChange={this.handleChange}
+                min="0"
               />
             </label>
           </div>

--- a/src/demo/styles.css
+++ b/src/demo/styles.css
@@ -104,6 +104,15 @@ a {
 
 .margin-top--small {
   margin-top: 1rem;
+  margin-bottom: -1rem;
+}
+
+.margin-top--small > div {
+  flex-wrap: wrap;
+}
+
+.margin-top--small > div > div {
+  margin-bottom: 1rem;
 }
 
 .margin-top--medium {


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
This PR is for the demo site and it adds a wrap property to the singleOtpBox flex container so that a higher numInputs value doesn't let the container overflow. I have also added a min value for the numInputs input box so that it doesn't take in a negative value.

- **Screenshots and/or Live Demo**

**Before** fixing the singleOtpBox container overflow issue.
![before-overflow](https://user-images.githubusercontent.com/31811117/66149159-1bc19180-e630-11e9-8151-5ac3dbfe4ab2.png)

**Before** fixing the numInputs input box taking negative values.
![numinputs-negativeValue](https://user-images.githubusercontent.com/31811117/66149194-2c720780-e630-11e9-8cee-72273cbfea08.png)

**After** fixing the singleOtpBox container overflow issue.
![after-overflow-fixed](https://user-images.githubusercontent.com/31811117/66149314-7529c080-e630-11e9-8e4c-ddb1ce250b81.png)

