### PR TITLE
Ignore text input when isInputNum is true, fixes #50

### DIFF
--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -102,7 +102,7 @@ class SingleOtpInput extends PureComponent<*> {
             isDisabled && disabledStyle,
             hasErrored && errorStyle
           )}
-          type={isInputNum ? 'number' : 'tel'}
+          type='tel'
           {...numValueLimits}
           maxLength="1"
           ref={input => {
@@ -194,7 +194,12 @@ class OtpInput extends Component<Props, State> {
   };
 
   handleOnChange = (e: Object) => {
-    this.changeCodeAtFocus(e.target.value);
+    const { value } = e.target;
+    const { isInputNum } = this.props;
+    if (isInputNum && isNaN(Number(value))) {
+      return;
+    }
+    this.changeCodeAtFocus(value);
     this.focusNextInput();
   };
 


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
When OTP has `isInputNum=true`, text/letter will not be allowed to be entered in the input boxes.

`type='number'` is removed because number input doesn't trigger the `onChange` when `e` is entered, thus there is no way to restrict inputting letters in it. So now with `type='tel'` always, onChange is triggered always and we ignore `e` letter.

- **Any background context you want to provide?**
Fixes https://github.com/devfolioco/react-otp-input/issues/50

