### PR TITLE
Update index.jsx

### DIFF
--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -17,7 +17,7 @@ class Demo extends Component {
   }
 
   handleOtpChange = otp => {
-    this.setState({ otp });
+    this.setState({ otp : otp.toString() });
   };
 
   handleChange = e => {


### PR DESCRIPTION
hello @apollonian , this is for the issue #49.

The isInputNum checkbox was sending otp as a number type to the handleOtpChange method which was causing the GetOtp button as enabled even in a single input, so i use the toString() method to convert the otp to string.There are still some other issues present in isinputNum checkbox i will raise a new issue for it,Thanks. 

