### PR TITLE
Fix bug with otp codes starting with zero being stripped

### DIFF
--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -138,7 +138,7 @@ class OtpInput extends Component<Props, State> {
   handleOtpChange = (otp: string[]) => {
     const { onChange, isInputNum } = this.props;
     const otpValue = otp.join('');
-    onChange(isInputNum ? Number(otpValue) : otpValue);
+    onChange(otpValue);
   };
 
   // Focus on input by index


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
Fixes the bug where when entering an otp that starts with zero the entire otp value would be cleared

- **Any background context you want to provide?**

- **Screenshots and/or Live Demo**
