### PR TITLE
Fixes issues related to arrow keys appearing in firefox browser on isInputNum field enabled

### DIFF
--- a/src/demo/styles.css
+++ b/src/demo/styles.css
@@ -82,12 +82,16 @@ a {
   align-items: center;
 }
 
-input[type=number]::-webkit-inner-spin-button, 
-input[type=number]::-webkit-outer-spin-button { 
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
-    margin: 0; 
+input[type=number] {
+  -webkit-appearance: textfield;
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
 }
 
 .btn-row {


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
Fixes #83 

- **Any background context you want to provide?**
Modified appearance for input type="number" to `textfield` with different browsers support.
- **Screenshots and/or Live Demo**
Browser - Firefox - 69.0
![Peek 2019-10-16 17-49](https://user-images.githubusercontent.com/20622980/66918620-61715780-f03d-11e9-9e94-08540f42d028.gif)