### PR TITLE
Allow character input on mobile device

### DIFF
--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -103,7 +103,7 @@ class SingleOtpInput extends PureComponent<*> {
             isDisabled && disabledStyle,
             hasErrored && errorStyle
           )}
-          type={isInputNum ? 'number' : 'tel'}
+          type={isInputNum ? 'number' : 'text'}
           {...numValueLimits}
           maxLength="1"
           ref={input => {


### PR DESCRIPTION
Allow character input on mobile devices. In the on-screen keyboard, only the number input option is available even if isNumInput is false. 

<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
Allows character input on mobile devices
- **Any background context you want to provide?**
See the description
- **Screenshots and/or Live Demo**
![photo_2019-11-11_10-44-55](https://user-images.githubusercontent.com/15345994/68562576-565cec00-0470-11ea-8410-6f9bcb8bbb19.jpg)
