### PR TITLE
Passing className as a prop for styled-components support

### DIFF
--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -22,6 +22,7 @@ type Props = {
   shouldAutoFocus?: boolean,
   isInputNum?: boolean,
   value?: string,
+  className?: string
 };
 
 type State = {
@@ -82,11 +83,12 @@ class SingleOtpInput extends PureComponent<*> {
       shouldAutoFocus,
       isInputNum,
       value,
+      className,
       ...rest
     } = this.props;
 
     return (
-      <div style={{ display: 'flex', alignItems: 'center' }}>
+      <div className={className} style={{ display: 'flex', alignItems: 'center' }}>
         <input
           autoComplete="off"
           style={Object.assign(

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -271,6 +271,7 @@ class OtpInput extends Component<Props, State> {
       errorStyle,
       shouldAutoFocus,
       isInputNum,
+      className
     } = this.props;
     const otp = this.getOtpValue();
     const inputs = [];
@@ -300,6 +301,7 @@ class OtpInput extends Component<Props, State> {
           errorStyle={errorStyle}
           shouldAutoFocus={shouldAutoFocus}
           isInputNum={isInputNum}
+          className={className}
         />
       );
     }


### PR DESCRIPTION

- **What does this PR do?**

Exposes the `className` prop which styled-components requires to correctly style components.

- **Any background context you want to provide?**

See documentation on "styling any component": https://styled-components.com/docs/basics#styling-any-component

