### PR TITLE
Added Placeholder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ export default class App extends Component {
     <td>The value of the OTP passed into the component.</td>
   </tr>
   <tr>
+    <td>placeholder</td>
+    <td>string</td>
+    <td>false</td>
+    <td>none</td>
+    <td>Provide a custom placeholder. Should be a single character or a string of length <code>&lt;numInputs&lt;</code>.</td>
+  </tr>
+  <tr>
     <td>separator</td>
     <td>component<br/></td>
     <td>false</td>

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -149,13 +149,9 @@ class OtpInput extends Component<Props, State> {
         return;
       }
 
-      if (placeholder.length === 1) {
-        return placeholder.repeat(numInputs);
-      } else if (placeholder.length === numInputs) {
-        return placeholder;
-      } else {
-        console.error('Invalid placeholder value');
-      }
+      if (placeholder.length === 1) return placeholder.repeat(numInputs);
+      else if (placeholder.length === numInputs) return placeholder;
+      else console.error('Invalid placeholder value');
     }
   };
 

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -90,7 +90,10 @@ class SingleOtpInput extends PureComponent<*> {
     } = this.props;
 
     return (
-      <div className={className} style={{ display: 'flex', alignItems: 'center' }}>
+      <div
+        className={className}
+        style={{ display: 'flex', alignItems: 'center' }}
+      >
         <input
           autoComplete="off"
           style={Object.assign(
@@ -140,18 +143,19 @@ class OtpInput extends Component<Props, State> {
 
   getPlaceholderValue = () => {
     const { placeholder, numInputs } = this.props;
+    if (placeholder !== undefined) {
+      if (typeof placeholder !== 'string') {
+        console.error('Placeholder should be a string');
+        return;
+      }
 
-    if (typeof placeholder !== 'string'){
-      console.error("Placeholder should be a string");
-      return;
-    } 
-
-    if (placeholder.length === 1) {
-      return placeholder.repeat(numInputs);
-    } else if (placeholder.length === numInputs) {
-      return placeholder;
-    } else {
-      console.error('Invalid placeholder value');
+      if (placeholder.length === 1) {
+        return placeholder.repeat(numInputs);
+      } else if (placeholder.length === numInputs) {
+        return placeholder;
+      } else {
+        console.error('Invalid placeholder value');
+      }
     }
   };
 
@@ -291,7 +295,7 @@ class OtpInput extends Component<Props, State> {
       errorStyle,
       shouldAutoFocus,
       isInputNum,
-      className
+      className,
     } = this.props;
     const otp = this.getOtpValue();
     const inputs = [];

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -143,16 +143,12 @@ class OtpInput extends Component<Props, State> {
 
   getPlaceholderValue = () => {
     const { placeholder, numInputs } = this.props;
-    if (placeholder !== undefined) {
-      if (typeof placeholder !== 'string') {
-        console.error('Placeholder should be a string');
-        return;
-      }
-
+    if (typeof placeholder === 'string') {
       if (placeholder.length === 1) return placeholder.repeat(numInputs);
       else if (placeholder.length === numInputs) return placeholder;
       else console.error('Invalid placeholder value');
     }
+    return;
   };
 
   // Helper to return OTP from input

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -146,7 +146,7 @@ class OtpInput extends Component<Props, State> {
     if (typeof placeholder === 'string') {
       if (placeholder.length === 1) return placeholder.repeat(numInputs);
       else if (placeholder.length === numInputs) return placeholder;
-      else console.error('Invalid placeholder value');
+      else console.error('Invalid placeholder length');
     }
     return;
   };

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -9,6 +9,7 @@ const DELETE = 46;
 const SPACEBAR = 32;
 
 type Props = {
+  placeholder: string,
   numInputs: number,
   onChange: Function,
   separator?: Object,
@@ -71,6 +72,7 @@ class SingleOtpInput extends PureComponent<*> {
 
   render() {
     const {
+      placeholder,
       separator,
       isLastChild,
       inputStyle,
@@ -98,6 +100,7 @@ class SingleOtpInput extends PureComponent<*> {
             isDisabled && isStyleObject(disabledStyle) && disabledStyle,
             hasErrored && isStyleObject(errorStyle) && errorStyle
           )}
+          placeholder={placeholder}
           className={this.getClasses(
             inputStyle,
             focus && focusStyle,
@@ -134,6 +137,22 @@ class OtpInput extends Component<Props, State> {
 
   getOtpValue = () =>
     this.props.value ? this.props.value.toString().split('') : [];
+
+  getPlaceholderValue=()=>{
+    const {placeholder,numInputs}= this.props;
+
+    if(!placeholder) return;
+    
+    if(placeholder.length===1){
+      return placeholder.repeat(numInputs);
+    }
+    else if(placeholder.length===numInputs){
+      return placeholder
+    }
+    else{
+      console.error("Invalid placeholder value");
+    }
+  }
 
   // Helper to return OTP from input
   handleOtpChange = (otp: string[]) => {
@@ -275,10 +294,11 @@ class OtpInput extends Component<Props, State> {
     } = this.props;
     const otp = this.getOtpValue();
     const inputs = [];
-
+    const placeholder = this.getPlaceholderValue();
     for (let i = 0; i < numInputs; i++) {
       inputs.push(
         <SingleOtpInput
+          placeholder={placeholder && placeholder[i]}
           key={i}
           focus={activeInput === i}
           value={otp && otp[i]}

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -23,7 +23,7 @@ type Props = {
   shouldAutoFocus?: boolean,
   isInputNum?: boolean,
   value?: string,
-  className?: string
+  className?: string,
 };
 
 type State = {
@@ -138,21 +138,22 @@ class OtpInput extends Component<Props, State> {
   getOtpValue = () =>
     this.props.value ? this.props.value.toString().split('') : [];
 
-  getPlaceholderValue=()=>{
-    const {placeholder,numInputs}= this.props;
+  getPlaceholderValue = () => {
+    const { placeholder, numInputs } = this.props;
 
-    if(!placeholder) return;
-    
-    if(placeholder.length===1){
+    if (typeof placeholder !== 'string'){
+      console.error("Placeholder should be a string");
+      return;
+    } 
+
+    if (placeholder.length === 1) {
       return placeholder.repeat(numInputs);
+    } else if (placeholder.length === numInputs) {
+      return placeholder;
+    } else {
+      console.error('Invalid placeholder value');
     }
-    else if(placeholder.length===numInputs){
-      return placeholder
-    }
-    else{
-      console.error("Invalid placeholder value");
-    }
-  }
+  };
 
   // Helper to return OTP from input
   handleOtpChange = (otp: string[]) => {

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -146,7 +146,7 @@ class OtpInput extends Component<Props, State> {
     if (typeof placeholder === 'string') {
       if (placeholder.length === 1) return placeholder.repeat(numInputs);
       else if (placeholder.length === numInputs) return placeholder;
-      else console.error('Invalid placeholder length');
+      else console.error('Length of the placeholder should be either 1 or equal to the number of inputs');
     }
     return;
   };


### PR DESCRIPTION
**What does this PR do?**

- Added placeholder support.
- User can pass a string as placeholder prop
- If the string is of length 1, the character will be repeated across all inputs
- If the placeholder is of length `numLengths`, each character will be used as a placeholder for each input respectively.
- Will throw an error for invalid placeholder length.
- Fix #117 

**Demo**

- Placeholder is "1234" 
![image](https://user-images.githubusercontent.com/49222186/94718045-c0270280-036e-11eb-8e2d-8716a437ccba.png)

- Placeholder is "1"
![image](https://user-images.githubusercontent.com/49222186/94718089-d59c2c80-036e-11eb-99a6-9cfb393a4ff3.png)
