### PR TITLE
Input field focus change on copy pasted data

### DIFF
--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -184,7 +184,7 @@ class OtpInput extends Component<Props, State> {
   handleOnPaste = (e: Object) => {
     e.preventDefault();
     const { numInputs } = this.props;
-    const { activeInput } = this.state;
+    var { activeInput } = this.state;
     const otp = this.getOtpValue();
 
     // Get pastedData in an array of max size (num of inputs - current position)
@@ -197,8 +197,12 @@ class OtpInput extends Component<Props, State> {
     for (let pos = 0; pos < numInputs; ++pos) {
       if (pos >= activeInput && pastedData.length > 0) {
         otp[pos] = pastedData.shift();
+        activeInput++;
       }
     }
+
+    this.setState({ activeInput });
+    this.focusInput(activeInput);
 
     this.handleOtpChange(otp);
   };


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
When pasting a number copied earlier, the focus of the field does not change. This PR fixes that issue #121 

- **Any background context you want to provide?**
![problemScreenshot](https://user-images.githubusercontent.com/17003127/94774434-8a6c3300-03db-11eb-8589-3e3c61f277b2.png)

![error](https://user-images.githubusercontent.com/17003127/94777343-f735fc00-03e0-11eb-93f9-5efef1e7c26e.gif)

- **Screenshots and/or Live Demo**

![solved](https://user-images.githubusercontent.com/17003127/94780224-ba203880-03e5-11eb-8e14-8f4fd06f4b30.gif)
