### PR TITLE
fixed issue of clear value on backspace and issue of focus when copy …

### DIFF
--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -173,7 +173,7 @@ class OtpInput extends Component<Props, State> {
 
   // Change OTP value at focused input
   changeCodeAtFocus = (value: string) => {
-    const { activeInput } = this.state;
+    var { activeInput } = this.state;
     const otp = this.getOtpValue();
     otp[activeInput] = value[0];
 
@@ -184,7 +184,7 @@ class OtpInput extends Component<Props, State> {
   handleOnPaste = (e: Object) => {
     e.preventDefault();
     const { numInputs } = this.props;
-    const { activeInput } = this.state;
+    let { activeInput } = this.state;
     const otp = this.getOtpValue();
 
     // Get pastedData in an array of max size (num of inputs - current position)
@@ -197,8 +197,11 @@ class OtpInput extends Component<Props, State> {
     for (let pos = 0; pos < numInputs; ++pos) {
       if (pos >= activeInput && pastedData.length > 0) {
         otp[pos] = pastedData.shift();
+        activeInput++;
       }
     }
+    this.setState({ activeInput });
+    this.focusInput(activeInput);
 
     this.handleOtpChange(otp);
   };
@@ -215,11 +218,10 @@ class OtpInput extends Component<Props, State> {
   handleOnKeyDown = (e: Object) => {
     if (e.keyCode === BACKSPACE || e.key === 'Backspace') {
       e.preventDefault();
-      this.changeCodeAtFocus('');
-      this.focusPrevInput();
+      this.changeCodeAtFocus('_');
     } else if (e.keyCode === DELETE || e.key === 'Delete') {
       e.preventDefault();
-      this.changeCodeAtFocus('');
+      this.changeCodeAtFocus('_');
     } else if (e.keyCode === LEFT_ARROW || e.key === 'ArrowLeft') {
       e.preventDefault();
       this.focusPrevInput();


### PR DESCRIPTION
Fixed issue #122  of clear value when pressed backspace or delete button.  When the user clears the value, it is replaced by '_', so that the user can change the value at that place only instead of clearing whole OTP and re-entering it.

Fixed issue #100, When pressed Backspace the cursor is now remaining on its place. 

Also fixed  the issue #121 of focus to current value when OTP is copied and Pasted.
