### PR TITLE
Added placeholder feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ export default class App extends Component {
     <td>false</td>
     <td>Restrict input to only numbers.</td>
   </tr>
+  <tr>
+     <td>placeholder</td>
+     <td>string</td>
+     <td>false</td>
+     <td>0000</td>
+     <td>Provide a custom placeholder. Can be a single character or a string of length numInputs</td>
+   </tr>
 </table>
 
 ## Breaking changes when porting to v1.0.0

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -22,7 +22,8 @@ type Props = {
   shouldAutoFocus?: boolean,
   isInputNum?: boolean,
   value?: string,
-  className?: string
+  className?: string,
+  placeholder: string,
 };
 
 type State = {
@@ -84,6 +85,7 @@ class SingleOtpInput extends PureComponent<*> {
       isInputNum,
       value,
       className,
+      placeholder,
       ...rest
     } = this.props;
 
@@ -112,6 +114,7 @@ class SingleOtpInput extends PureComponent<*> {
           disabled={isDisabled}
           value={value ? value : ''}
           {...rest}
+          placeholder={placeholder}
         />
         {!isLastChild && separator}
       </div>
@@ -130,6 +133,26 @@ class OtpInput extends Component<Props, State> {
 
   state = {
     activeInput: 0,
+  };
+
+  getPlaceholderValue = () => {
+    const { placeholder, numInputs } = this.props;
+    if(placeholder === undefined){
+      return "0".repeat(numInputs);
+    } else {
+      if (typeof placeholder !== 'string') {
+        console.error('Placeholder type not valid. It should be of typestring.');
+        return;
+      }
+      
+       if (placeholder.length === 1) {
+        return placeholder.repeat(numInputs);
+      } else if (placeholder.length === numInputs) {
+        return placeholder;
+      } else {
+        console.error('Placeholder value not valid.');
+      }
+    }
   };
 
   getOtpValue = () =>
@@ -275,6 +298,7 @@ class OtpInput extends Component<Props, State> {
     } = this.props;
     const otp = this.getOtpValue();
     const inputs = [];
+    const placeholder = this.getPlaceholderValue();
 
     for (let i = 0; i < numInputs; i++) {
       inputs.push(
@@ -302,6 +326,7 @@ class OtpInput extends Component<Props, State> {
           shouldAutoFocus={shouldAutoFocus}
           isInputNum={isInputNum}
           className={className}
+          placeholder={placeholder && placeholder[i]}
         />
       );
     }


### PR DESCRIPTION
**What does this PR do?**
- If user does not pass any value for a placeholder, It will be automatically getting set to a string of zeroes of length numInput.
- If user passes a string of length 1, Placeholder will be set to a string with only that value
- Otherwise, user will have to pass a string of length numInputs which will be used as a placeholder.
- Fixing Issue #117 

**Screenshots and/or Live Demo**
- When "1234" is passed as placeholder
<img width="1440" alt="Screenshot 2020-10-02 at 1 24 03 AM" src="https://user-images.githubusercontent.com/40268761/94856735-04d59b00-044e-11eb-8e76-f38ce9451544.png">

- When "1" is passed as placeholder
<img width="1440" alt="Screenshot 2020-10-02 at 1 23 50 AM" src="https://user-images.githubusercontent.com/40268761/94856749-0acb7c00-044e-11eb-8c3e-1cfaadb09dee.png">

- When placeholder is not passed
<img width="1440" alt="Screenshot 2020-10-02 at 1 22 43 AM" src="https://user-images.githubusercontent.com/40268761/94856755-0c953f80-044e-11eb-8c62-a71053974a13.png">
