### PR TITLE
disable clear button when otp field is empty

### DIFF
--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -183,7 +183,7 @@ class Demo extends Component {
                 <button
                   className="btn margin-top--large"
                   type="button"
-                  disabled={isDisabled || this.state.otp.trim() === ""}
+                  disabled={isDisabled || otp.trim() === ""}
                   onClick={this.clearOtp}
                 >
                   Clear

--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -183,7 +183,7 @@ class Demo extends Component {
                 <button
                   className="btn margin-top--large"
                   type="button"
-                  disabled={isDisabled}
+                  disabled={isDisabled || this.state.otp.trim() === ""}
                   onClick={this.clearOtp}
                 >
                   Clear


### PR DESCRIPTION
- **What does this PR do?**
currently, the clear button is **active** even if OTP input fields are empty which doesn't have any use when the field is empty. This PR will fix this issue and make clear button **disabled** when the input field of OTP is empty. Fix #158 

- **Screenshots and/or Live Demo**

**Before Fix of this issue**
![Screenshot from 2020-10-02 11-19-39](https://user-images.githubusercontent.com/45959932/94892016-3d529480-04a1-11eb-92c2-b61d041e0195.png)

**After Fix of this issue**
![Screenshot from 2020-10-02 11-19-52](https://user-images.githubusercontent.com/45959932/94892024-4479a280-04a1-11eb-9d26-c40f7fbd5a7e.png)

