### PR TITLE
Fixed issue of focus going to previous element when pressed backspace

### DIFF
--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -216,7 +216,6 @@ class OtpInput extends Component<Props, State> {
     if (e.keyCode === BACKSPACE || e.key === 'Backspace') {
       e.preventDefault();
       this.changeCodeAtFocus('');
-      this.focusPrevInput();
     } else if (e.keyCode === DELETE || e.key === 'Delete') {
       e.preventDefault();
       this.changeCodeAtFocus('');


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?** 
This PR fixes #100, when user clicks backspace in an element the focus will now remain in the current element instead of going to the previous element. This will allow users to correct a single element without having to delete the whole OTP and re-enter it again!!
