### PR TITLE
styled disabled btn cursor to not-allowed

### DIFF
--- a/src/demo/styles.css
+++ b/src/demo/styles.css
@@ -181,7 +181,7 @@ input[type=number] {
 
 .btn:disabled {
   background-color: rgba(0, 0, 0, 0.4);
-  cursor: default;
+  cursor: not-allowed;
 }
 
 .margin-top--small {


### PR DESCRIPTION
 **What does this PR do?**
currently disable buttons cursor type is default, but for disable buttons not-allowed cursor type is more relevant. This PR will fix this small issue. fix #158 
 **Screenshots and/or Live Demo**
**Before fix**:-
![allowed cursor](https://user-images.githubusercontent.com/45959932/94902244-7a288680-04b5-11eb-96c0-abbfc60fd7f1.gif)
**After Fix**:-
![not-allowed cursor](https://user-images.githubusercontent.com/45959932/94902285-8a406600-04b5-11eb-9b0c-63120e0fbcf7.gif)
