### PR TITLE
-added condition for button disable action

### DIFF
--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -183,14 +183,14 @@ class Demo extends Component {
                 <button
                   className="btn margin-top--large"
                   type="button"
-                  disabled={isDisabled}
+                  disabled={isDisabled || !numInputs || !otp}
                   onClick={this.clearOtp}
                 >
                   Clear
                 </button>
                 <button
                   className="btn margin-top--large"
-                  disabled={otp.length < numInputs}
+                  disabled={otp.length < numInputs || !numInputs}
                 >
                   Get OTP
                 </button>


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
1. if  ```numInputs``` is not set, it will disable the ```Clear``` and ```get-OTP``` buttons.
2. if the OTP field is empty, it will disable the ```Clear``` button.


- **Any background context you want to provide?**
if ```numInputs``` is not set, to provide clarity the buttons should be disabled.
![image](https://user-images.githubusercontent.com/42478217/94928303-1ddb5c00-04e1-11eb-9d1b-de898993a5a5.png)

**There are multiple PRs for point 2, I just added a fix in here too.
