### PR TITLE
feat: add onKeyDown prop to detect other key event

### DIFF
--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -8,6 +8,11 @@ const RIGHT_ARROW = 39;
 const DELETE = 46;
 const SPACEBAR = 32;
 
+type KeyDownProp = {
+  keyCode: number,
+  cb: Function
+}
+
 type Props = {
   placeholder: string,
   numInputs: number,
@@ -24,6 +29,7 @@ type Props = {
   isInputNum?: boolean,
   value?: string,
   className?: string,
+  onKeyDown?: KeyDownProp
 };
 
 type State = {
@@ -288,6 +294,7 @@ class OtpInput extends Component<Props, State> {
       shouldAutoFocus,
       isInputNum,
       className,
+      onKeyDown
     } = this.props;
     const otp = this.getOtpValue();
     const inputs = [];
@@ -300,7 +307,12 @@ class OtpInput extends Component<Props, State> {
           focus={activeInput === i}
           value={otp && otp[i]}
           onChange={this.handleOnChange}
-          onKeyDown={this.handleOnKeyDown}
+          onKeyDown={(e: Object) => {
+            if (onKeyDown.keyCode === e.keyCode)
+              onKeyDown.cb();
+            else
+              this.handleOnKeyDown(e)
+          }}
           onInput={this.handleOnInput}
           onPaste={this.handleOnPaste}
           onFocus={e => {


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
Adds a onKeyDown prop to detect key events other than backspace, left arrow, right arrow, delete.

- **Any background context you want to provide?**
Using the onKeyDown prop, the user doesn't need to wrap the OtpInput component inside a form element. They can use the onKeyDown prop to pass a callback function which will be called when the specified keycode is pressed.

- **Screenshots and/or Live Demo**

Fixes #98
