### PR TITLE
haserror should not display error color if input is empty.

### DIFF
--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -292,6 +292,7 @@ class OtpInput extends Component<Props, State> {
     const otp = this.getOtpValue();
     const inputs = [];
     const placeholder = this.getPlaceholderValue();
+    console.log(otp)
     for (let i = 0; i < numInputs; i++) {
       inputs.push(
         <SingleOtpInput
@@ -314,7 +315,7 @@ class OtpInput extends Component<Props, State> {
           isLastChild={i === numInputs - 1}
           isDisabled={isDisabled}
           disabledStyle={disabledStyle}
-          hasErrored={hasErrored}
+          hasErrored={hasErrored&&otp[i]?true:false}
           errorStyle={errorStyle}
           shouldAutoFocus={shouldAutoFocus}
           isInputNum={isInputNum}


### PR DESCRIPTION
- **What does this PR do**
There is a feature of `hasErrored` which sets border color to `red` of input. The default behavior is, it will show border-color red even input is empty which is bad user experience. This PR is to fix this issue.

# Current behavior 
![image](https://github.com/Ats1999/Assingment/blob/master/public/Screenshot%20(375).png?raw=true)

# Behavior after this PR
![](https://github.com/Ats1999/Assingment/blob/master/public/Screenshot%20(374).png?raw=true)
![](https://github.com/Ats1999/Assingment/blob/master/public/Screenshot%20(373).png?raw=true)
