### PR TITLE
Issue fixed in which Separators with letters and numbers were considered

### DIFF
--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -17,6 +17,7 @@ class Demo extends Component {
       isInputNum: false,
       minLength: 0,
       maxLength: 40,
+      btndisable:false
     };
   }
 
@@ -37,6 +38,23 @@ class Demo extends Component {
           `Please enter a value between ${minLength} and ${maxLength}`
         );
       }
+    }
+    if(e.target.name==='separator')
+    {
+      //console.log("currVal=",currVal);
+      if(currVal.length===0)
+      {alert("Enter the separator otherwise Get OTP button will be disabled.");this.setState({btndisable:true});}
+      else if(currVal===' ')
+      {currVal=' ';this.setState({btndisable:false});}
+      else if(currVal=== '-')
+      {currVal='-';this.setState({btndisable:false});}
+      else if(currVal==='.')
+      {currVal='.';this.setState({btndisable:false});}
+      else
+      {alert("separator should be either hyphen ('-') , dot ('.') or whitespace(' ') ");this.setState({btndisable:true});currVal='';}
+      //console.log(currVal.length);
+      
+      
     }
 
     this.setState({ [e.target.name]: currVal });
@@ -190,7 +208,7 @@ class Demo extends Component {
                 </button>
                 <button
                   className="btn margin-top--large"
-                  disabled={otp.length < numInputs}
+                  disabled={otp.length < numInputs || this.state.btndisable===true}
                 >
                   Get OTP
                 </button>


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
In this PR, I fixed the issue #195  in which letters and numbers were accepted as separators so I limited the number of separators to hyphen , dot or whitespace.
![2020-10-03](https://user-images.githubusercontent.com/48866201/94992895-cef9f900-05aa-11eb-80a2-521ffdb3c718.png)

- **Any background context you want to provide?**
So, if separator is valid then only the 'get otp' button will work or else it will be disabled.
- **Screenshots and/or Live Demo**
Initial Page
![2020-10-03 (1)](https://user-images.githubusercontent.com/48866201/94992642-1b443980-05a9-11eb-8455-e02a5c5a287d.png)
On Clearing the Separator,alert will be displayed
![2020-10-03 (2)](https://user-images.githubusercontent.com/48866201/94992628-0798d300-05a9-11eb-98c2-c06a4e3d3654.png)
On Entering dot as separator
![2020-10-03 (3)](https://user-images.githubusercontent.com/48866201/94992677-4af34180-05a9-11eb-9d7e-feeae516d095.png)
On entering letter or number as separator , an alert will be displayed and 'get otp' button will be disabled.
![2020-10-03 (4)](https://user-images.githubusercontent.com/48866201/94992698-61999880-05a9-11eb-8cad-f133e916785f.png)
On entering whitespace as separator
![2020-10-03 (5)](https://user-images.githubusercontent.com/48866201/94992927-01a3f180-05ab-11eb-80db-550a897bb9ed.png)
On clicking 'Get OTP' button with whitespace as separator
![2020-10-03 (7)](https://user-images.githubusercontent.com/48866201/94993063-eeddec80-05ab-11eb-8f51-d2cb1d74b7ba.png)

