### PR TITLE
added a prop for OTP which generates a test id for elements

### DIFF
--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -24,6 +24,7 @@ type Props = {
   isInputNum?: boolean,
   value?: string,
   className?: string,
+  testprop?: string,
 };
 
 type State = {
@@ -87,6 +88,7 @@ class SingleOtpInput extends PureComponent<*> {
       index,
       value,
       className,
+      testProp,
       ...rest
     } = this.props;
 
@@ -119,6 +121,7 @@ class SingleOtpInput extends PureComponent<*> {
           }}
           disabled={isDisabled}
           value={value ? value : ''}
+          id={testProp}
           {...rest}
         />
         {!isLastChild && separator}
@@ -290,6 +293,7 @@ class OtpInput extends Component<Props, State> {
       shouldAutoFocus,
       isInputNum,
       className,
+      testProp,
     } = this.props;
     const otp = this.getOtpValue();
     const inputs = [];
@@ -322,6 +326,7 @@ class OtpInput extends Component<Props, State> {
           shouldAutoFocus={shouldAutoFocus}
           isInputNum={isInputNum}
           className={className}
+          testProp={testProp ? testProp.concat(i + 1) : null}
         />
       );
     }


### PR DESCRIPTION
- **What does this PR do?**
This PR adds an optional field to OtpInput which allows users to specify a test value prefix to identify the object in testing environments. The prop is completely option and will effect the SingleOtp's id when compiled to html.

- **Any background context you want to provide?**
This PR intends to satisfy issue #96 to the best of my understanding. Any modifications necessary let me know.

- **Screenshots and/or Live Demo**

**Prior to adding a 'testProp' property**
![Screen Shot 2020-10-03 at 10 47 36 PM](https://user-images.githubusercontent.com/12114542/95006465-733f6800-05ca-11eb-9a27-f9e9e0f2b56c.png)

**After adding the 'testProp' property of 'test-'**
<img width="505" alt="Screen Shot 2020-10-03 at 10 46 47 PM" src="https://user-images.githubusercontent.com/12114542/95006457-586cf380-05ca-11eb-812f-5790f635e772.png">

**Notice the ID test-2 in the above screenshot, the test values are ones indexed like issue request wanted so that was the second input field**

**The OTPInput**
![Screen Shot 2020-10-03 at 10 49 12 PM](https://user-images.githubusercontent.com/12114542/95006488-a97ce780-05ca-11eb-8246-b982d7b7a341.png)
