### PR TITLE
Autofocus 1st input on error

### DIFF
--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -29,6 +29,7 @@ type Props = {
 type State = {
   activeInput: number,
   otp: string[],
+  hasFocusedOnceErrored: boolean
 };
 
 // Doesn't really check if it's a style Object
@@ -138,7 +139,22 @@ class OtpInput extends Component<Props, State> {
 
   state = {
     activeInput: 0,
+    hasFocusedOnceErrored: false
   };
+
+    static getDerivedStateFromProps(props, state) {
+    if(
+      props.hasErrored === true &&
+      state.hasFocusedOnceErrored === false
+    ) {
+      return {
+        ...state,
+        activeInput: 0,
+        hasFocusedOnceErrored: true
+      }
+    }
+    return state;
+  }
 
   getOtpValue = () =>
     this.props.value ? this.props.value.toString().split('') : [];
@@ -179,7 +195,10 @@ class OtpInput extends Component<Props, State> {
 
   // Focus on next input
   focusNextInput = () => {
-    const { activeInput } = this.state;
+    const { activeInput, hasFocusedOnceErrored } = this.state;
+    if (hasFocusedOnceErrored) {
+      this.setState({ hasFocusedOnceErrored: true });
+    }
     this.focusInput(activeInput + 1);
   };
 


### PR DESCRIPTION
- **What does this PR do?**

The PR adds functionality where when an error occurs, 1st cell is made as active

- **Any background context you want to provide?**

Based on comments on this issue: https://github.com/devfolioco/react-otp-input/issues/14#issuecomment-676439567

- **Issue**

https://github.com/devfolioco/react-otp-input/issues/14

- **Screenshots and/or Live Demo**

![Kapture 2020-10-06 at 21 41 17](https://user-images.githubusercontent.com/7746087/95228249-b98c0580-081c-11eb-9296-47eea1ea99d6.gif)
