### PR TITLE
Added github action to build and deploy demo

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -1,0 +1,27 @@
+name: Build Example Site
+on: 
+  push:
+    branches:
+      - master
+      
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1 
+        with:
+          persist-credentials: false
+
+      - name: Install and Build 🔧 
+        run: |
+          npm install
+          npm run demo:prod
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@3.6.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages 
+          FOLDER: demo 
+          CLEAN: true 


### PR DESCRIPTION
- Added GitHub action to automatically build and deploy the demo page to Github pages
- This happens in every push to the `master`
- Inspired from [devfolioco/react-copy-mailto](https://github.com/devfolioco/react-copy-mailto) & [JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action)

- fix #225