### PR TITLE
Implement react-otp-input within docz docmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,25 +200,3 @@ Feel free to open [issues](https://github.com/devfolioco/react-otp-input/issues/
 ## License
 
 [![NPM](https://img.shields.io/npm/l/react-otp-input)](https://github.com/devfolioco/react-otp-input/blob/master/LICENSE)
-
-## Contributors ✨
-
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
-
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
-<!-- markdownlint-disable -->
-<table>
-  <tr>
-    <td align="center"><a href="https://github.com/apollonian"><img src="https://avatars2.githubusercontent.com/u/2150306?v=4" width="100px;" alt=""/><br /><sub><b>Abhishek Warokar</b></sub></a><br /><a href="https://github.com/devfolioco/react-otp-input/commits?author=apollonian" title="Code">💻</a> <a href="#design-apollonian" title="Design">🎨</a> <a href="#maintenance-apollonian" title="Maintenance">🚧</a> <a href="#ideas-apollonian" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/devfolioco/react-otp-input/pulls?q=is%3Apr+reviewed-by%3Aapollonian" title="Reviewed Pull Requests">👀</a></td>
-    <td align="center"><a href="https://ajayns.me"><img src="https://avatars0.githubusercontent.com/u/20743219?v=4" width="100px;" alt=""/><br /><sub><b>Aj</b></sub></a><br /><a href="https://github.com/devfolioco/react-otp-input/commits?author=ajayns" title="Code">💻</a> <a href="#design-ajayns" title="Design">🎨</a> <a href="#ideas-ajayns" title="Ideas, Planning, & Feedback">🤔</a></td>
-    <td align="center"><a href="http://aromalanil.me"><img src="https://avatars1.githubusercontent.com/u/49222186?v=4" width="100px;" alt=""/><br /><sub><b>Aromal Anil</b></sub></a><br /><a href="https://github.com/devfolioco/react-otp-input/commits?author=aromalanil" title="Code">💻</a></td>
-    <td align="center"><a href="https://borntofrappe.github.io"><img src="https://avatars0.githubusercontent.com/u/33316703?v=4" width="100px;" alt=""/><br /><sub><b>Gabriele Corti</b></sub></a><br /><a href="https://github.com/devfolioco/react-otp-input/commits?author=borntofrappe" title="Code">💻</a> <a href="#a11y-borntofrappe" title="Accessibility">️️️️♿️</a></td>
-  </tr>
-</table>
-
-<!-- markdownlint-enable -->
-<!-- prettier-ignore-end -->
-<!-- ALL-CONTRIBUTORS-LIST:END -->
-
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/docs/demo.mdx
+++ b/docs/demo.mdx
@@ -1,0 +1,44 @@
+---
+name: Demo
+route: /docs-demo
+---
+
+import { Playground, Props } from 'docz';
+import OtpInput from '../lib/index.js';
+import '../src/demo/styles.css';
+
+<Playground>
+    {class ExampleButton extends React.Component {
+            constructor(props) {
+            super(props);
+                this.state = {
+                    otp: '',
+                    numInputs: 4,
+                    separator: '-',
+                    isDisabled: false,
+                    hasErrored: false,
+                    isInputNum: false,
+                    minLength: 0,
+                    maxLength: 40,
+                };
+            }
+            render() {
+                const { inverted } = this.state;
+                return (
+                    <OtpInput
+                    inputStyle="inputStyle"
+                    numInputs={this.state.numInputs}
+                    isDisabled={this.state.isDisabled}
+                    hasErrored={this.state.hasErrored}
+                    errorStyle="error"
+                    onChange={(otp)=>{this.setState({otp})}}
+                    separator={<span>-</span>}
+                    isInputNum={this.state.isInputNum}
+                    shouldAutoFocus
+                    value={this.state.otp}
+                    />
+                );
+            }
+        }
+}
+</Playground>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,0 @@
----
-name: React Otp Input
-menu: Components
----
-
-# React Otp Input

--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -21,6 +21,7 @@ class Demo extends Component {
   }
 
   handleOtpChange = otp => {
+    console.log(otp);
     this.setState({ otp });
   };
 


### PR DESCRIPTION

- **What does this PR do?**
Fixed #210

- **Any background context you want to provide?**
I initially wanted to render the demo in the README.md file. If you copy-paste all content from `demo.mdx` into `README.md`, it works really well on the docz server, but that JSX is also printed directly (with no formatting) in markdown. Therefore we'd have had a great documentation website, but ugly JSX code in the repository's README. That's why I felt it'd be better if the demo is kept separately from the README.

If there's a way for JSX to be shown on docz but not on README, please let me know. I've searched online but I couldn't find any way for it.

- **Screenshots and/or Live Demo**

![Screenshot from 2020-10-08 12-17-47](https://user-images.githubusercontent.com/25480443/95424523-61f6b280-0960-11eb-919d-c6534a3c8f92.png)
