### PR TITLE
Remove comment in README to run Docz server

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,6 @@ export default class App extends Component {
     <td>''</td>
     <td>The value of the OTP passed into the component.</td>
   </tr>
-  <!-- <tr>
-    <td>placeholder</td>
-    <td>string</td>
-    <td>false</td>
-    <td>none</td>
-    <td>Provide a custom placeholder. Should be a single character or a string of length <code>numInputs</code>.</td>
-  </tr> -->
   <tr>
     <td>separator</td>
     <td>component<br/></td>


### PR DESCRIPTION

- **What does this PR do?**
Fixes #209 

- **Any background context you want to provide?**
Docz also tries to render our README as an MDX style documentation file. Unfortunately, the docz server doesnt run when we comment anything in the README file. We had a comment in the README file, and this PR fixes it.

- **Screenshots and/or Live Demo**
