### PR TITLE
fix value field taking non digits on isInputNum

### DIFF
--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -40,6 +40,10 @@ class Demo extends Component {
       }
     }
 
+    if(this.state.isInputNum) {
+      currVal = currVal.replace(/[^\d]/g, '');
+    }
+
     this.setState({ [e.target.name]: currVal });
   };
 


### PR DESCRIPTION

- **What does this PR do?**
This PR fixes a minor bug in the DEMO index.js, where in, even if isInputNum is checked, the value text field on the left side of the page accepts Non Digits, and also changes the OTP field accordingly

- **Any background context you want to provide?**
the pr just removes the non digits with simple regex when isInputNum is checked

