### PR TITLE
Fix unshown input numbers in the iphone Safari (#265)

### DIFF
--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -115,7 +115,7 @@ class SingleOtpInput extends PureComponent<*> {
           }${isInputNum ? 'Digit' : 'Character'} ${index + 1}`}
           autoComplete="off"
           style={Object.assign(
-            { width: '1em', textAlign: 'center' },
+            { width: '1em', textAlign: 'center', padding: 0 },
             isStyleObject(inputStyle) && inputStyle,
             focus && isStyleObject(focusStyle) && focusStyle,
             isDisabled && isStyleObject(disabledStyle) && disabledStyle,


### PR DESCRIPTION
- **What does this PR do?**
Fix unshown input numbers in the iphone Safari.

- **Any background context you want to provide?**
issue #265
This issue happened because there's some padding on input element inline style inside SingleOtpInput component in my case