### PR TITLE
Add data attributes for test support

### DIFF
--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -309,6 +309,7 @@ class OtpInput extends Component {
       inputs.push(
         <SingleOtpInput
           placeholder={placeholder && placeholder[i]}
+          data-cy={this.props["data-cy"] ? `${this.props["data-cy"]}-${i}` : null}
           key={i}
           index={i}
           focus={activeInput === i}

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -86,9 +86,8 @@ class SingleOtpInput extends PureComponent {
         style={{ display: 'flex', alignItems: 'center' }}
       >
         <input
-          aria-label={`${
-            index === 0 ? 'Please enter verification code. ' : ''
-          }${isInputNum ? 'Digit' : 'Character'} ${index + 1}`}
+          aria-label={`${index === 0 ? 'Please enter verification code. ' : ''
+            }${isInputNum ? 'Digit' : 'Character'} ${index + 1}`}
           autoComplete="off"
           style={Object.assign(
             { width: '1em', textAlign: 'center' },
@@ -309,7 +308,6 @@ class OtpInput extends Component {
       inputs.push(
         <SingleOtpInput
           placeholder={placeholder && placeholder[i]}
-          data-cy={this.props["data-cy"] ? `${this.props["data-cy"]}-${i}` : null}
           key={i}
           index={i}
           focus={activeInput === i}
@@ -335,6 +333,8 @@ class OtpInput extends Component {
           isInputNum={isInputNum}
           isInputSecure={isInputSecure}
           className={className}
+          data-cy={this.props["data-cy"] ? `${this.props["data-cy"]}-${i}` : null}
+          data-testid={this.props["data-testid"] ? `${this.props["data-testid"]}-${i}` : null}
         />
       );
     }


### PR DESCRIPTION
- **What does this PR do?**
Fixes https://github.com/devfolioco/react-otp-input/issues/96
Continues https://github.com/devfolioco/react-otp-input/pull/206

This PR aims to add `data-cy` support for cypress E2E tests, and `data-testid` for react-testing-library tests.

- **Any background context you want to provide?**

Am using this library right now, but with my E2E tests I had to target `aria-label` which is not very resilient to changes.

- **Screenshots and/or Live Demo**
With data attributes set in the demo:
<img width="1459" alt="Screenshot 2021-06-23 at 11 27 41 PM" src="https://user-images.githubusercontent.com/2081441/123125438-1860e000-d47b-11eb-854b-1eeefe12891f.png">

Without data attributes set in the demo:
<img width="1465" alt="Screenshot 2021-06-23 at 11 27 49 PM" src="https://user-images.githubusercontent.com/2081441/123125454-1bf46700-d47b-11eb-8b20-08d947243cc3.png">
