### PR TITLE
Added feature to separate separtors periodically

### DIFF
--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -12,6 +12,7 @@ class Demo extends Component {
       otp: '',
       numInputs: 4,
       separator: '-',
+      separateAfter: 1,
       isDisabled: false,
       hasErrored: false,
       isInputNum: false,
@@ -62,6 +63,7 @@ class Demo extends Component {
       otp,
       numInputs,
       separator,
+      separateAfter,
       isDisabled,
       hasErrored,
       isInputNum,
@@ -102,6 +104,19 @@ class Demo extends Component {
                 name="separator"
                 type="text"
                 value={separator}
+                onChange={this.handleChange}
+              />
+            </label>
+          </div>
+          <div className="side-bar__segment">
+            <label htmlFor="separateAfter">
+              separate after
+              <input
+                id="separateAfter"
+                maxLength={1}
+                name="separateAfter"
+                type="text"
+                value={separateAfter}
                 onChange={this.handleChange}
               />
             </label>
@@ -177,6 +192,7 @@ class Demo extends Component {
                   errorStyle="error"
                   onChange={this.handleOtpChange}
                   separator={<span>{separator}</span>}
+                  separateAfter={separateAfter}
                   isInputNum={isInputNum}
                   isInputSecure={isInputSecure}
                   shouldAutoFocus

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -62,6 +62,7 @@ class SingleOtpInput extends PureComponent {
     const {
       placeholder,
       separator,
+      shouldRender,
       isLastChild,
       inputStyle,
       focus,
@@ -107,7 +108,7 @@ class SingleOtpInput extends PureComponent {
           value={value ? value : ''}
           {...rest}
         />
-        {!isLastChild && separator}
+        {!isLastChild && shouldRender && separator}
       </div>
     );
   }
@@ -274,6 +275,7 @@ class OtpInput extends Component {
       inputStyle,
       focusStyle,
       separator,
+      separateAfter,
       isDisabled,
       disabledStyle,
       hasErrored,
@@ -291,6 +293,12 @@ class OtpInput extends Component {
     const dataTestId = this.props['data-testid'];
 
     for (let i = 0; i < numInputs; i++) {
+      let shouldRender;
+      if(((i + 1) % parseInt(separateAfter)) === 0){
+        shouldRender = true;
+      } else {
+        shouldRender = false;
+      }
       inputs.push(
         <SingleOtpInput
           placeholder={placeholder && placeholder[i]}
@@ -308,6 +316,7 @@ class OtpInput extends Component {
           }}
           onBlur={() => this.setState({ activeInput: -1 })}
           separator={separator}
+          shouldRender={shouldRender}
           inputStyle={inputStyle}
           focusStyle={focusStyle}
           isLastChild={i === numInputs - 1}


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
This PR basically adds a feature using which a separator can be separated periodically.  [Issue 24](https://github.com/devfolioco/react-otp-input/issues/24)

- **Any background context you want to provide?**
This might actually be helpful. We can, later on, build this as a feature to totally customize the separator positions thus taking mobile number inputs for inputs like +91-XXXXXXXXXX or taking inputs for other use cases.

- **Screenshots and/or Live Demo**

![Screenshot 2021-10-02 at 2 54 32 PM](https://user-images.githubusercontent.com/17003127/135710670-93ec8d6d-0178-4fc8-a3c2-632016b70682.png)

![Screenshot 2021-10-02 at 2 55 16 PM](https://user-images.githubusercontent.com/17003127/135710686-52f30362-b881-44e8-8dd7-eb685f03224e.png)

![Screenshot 2021-10-02 at 2 55 47 PM](https://user-images.githubusercontent.com/17003127/135710699-63eac798-ce87-4313-aad7-791cb269bc69.png)


