### PR TITLE
Add optional attributes to support overridden test id attribute

### DIFF
--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -289,8 +289,13 @@ class OtpInput extends Component {
     const placeholder = this.getPlaceholderValue();
     const dataCy = this.props['data-cy'];
     const dataTestId = this.props['data-testid'];
+    const customTestAttr = this.props['custom-test-attr'];
+    const customTestId = this.props['custom-test-id'];
 
     for (let i = 0; i < numInputs; i++) {
+      const testAttr = {};
+      testAttr[customTestAttr] = customTestId && `${customTestId}-${i}`;
+
       inputs.push(
         <SingleOtpInput
           placeholder={placeholder && placeholder[i]}
@@ -321,6 +326,7 @@ class OtpInput extends Component {
           className={className}
           data-cy={dataCy && `${dataCy}-${i}`}
           data-testid={dataTestId && `${dataTestId}-${i}`}
+          {...testAttr}
         />
       );
     }

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -294,7 +294,9 @@ class OtpInput extends Component {
 
     for (let i = 0; i < numInputs; i++) {
       const testAttr = {};
-      testAttr[customTestAttr] = customTestId && `${customTestId}-${i}`;
+      if (customTestAttr) {
+        testAttr[customTestAttr] = customTestId && `${customTestId}-${i}`;
+      }
 
       inputs.push(
         <SingleOtpInput

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -44,6 +44,8 @@ interface OtpInputProps {
   value?: string;
   'data-testid'?: string;
   'data-cy'?: string;
+  'custom-test-attr'?: string;
+  'custom-test-id'?: string;
 }
 
 interface OtpInputState {


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
  Solved #315 by adding optional attributes to support [overridden test id attribute](https://testing-library.com/docs/queries/bytestid/#overriding-data-testid) 

- **Screenshots and/or Live Demo**
  Given the `custom-test-attr` and `custom-test-id`
  ```html
  <OtpInput
    inputStyle="inputStyle"
    numInputs={numInputs}
    ...
    custom-test-attr="custom-test-attr"
    custom-test-id="test-id"
  />
  ```
  here's the rendered result
  ![Screen Shot 2564-11-18 at 11 34 55](https://user-images.githubusercontent.com/1772999/142352467-87e08f98-7d5a-4f05-8610-d9d755ad7d15.png)

  
