### PR TITLE
feat: Add `id` and `autoComplete` props

### DIFF
--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -167,9 +167,11 @@ class Demo extends Component {
         <div className="view">
           <div className="card">
             <form onSubmit={this.handleSubmit}>
-              <p>Enter verification code</p>
+              <label htmlFor="otp-input-0">Enter verification code</label>
               <div className="margin-top--small">
                 <OtpInput
+                  id="otp-input"
+                  autoComplete="one-time-code"
                   inputStyle="inputStyle"
                   numInputs={numInputs}
                   isDisabled={isDisabled}

--- a/src/demo/styles.css
+++ b/src/demo/styles.css
@@ -78,7 +78,7 @@ a {
     font-size: 1rem;
   }
 
-  .card > form > p {
+  .card > form > label {
     font-size: 1.2em !important;
   }
 }
@@ -143,7 +143,7 @@ a {
   align-items: center;
 }
 
-.card > form > p {
+.card > form > label {
   font-size: 1.5em;
   font-weight: bold;
 }

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -85,7 +85,6 @@ class SingleOtpInput extends PureComponent {
           aria-label={`${index === 0 ? 'Please enter verification code. ' : ''}${isInputNum ? 'Digit' : 'Character'} ${
             index + 1
           }`}
-          autoComplete="off"
           style={Object.assign(
             { width: '1em', textAlign: 'center' },
             isStyleObject(inputStyle) && inputStyle,
@@ -270,6 +269,8 @@ class OtpInput extends Component {
   renderInputs = () => {
     const { activeInput } = this.state;
     const {
+      id,
+      autoComplete,
       numInputs,
       inputStyle,
       focusStyle,
@@ -293,6 +294,8 @@ class OtpInput extends Component {
     for (let i = 0; i < numInputs; i++) {
       inputs.push(
         <SingleOtpInput
+          id={id && `${id}-${i}`}
+          autoComplete={autoComplete ?? 'off'}
           placeholder={placeholder && placeholder[i]}
           key={i}
           index={i}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -26,6 +26,8 @@ declare class OtpInput extends React.Component<OtpInputProps, OtpInputState, any
 }
 
 interface OtpInputProps {
+  id?: string;
+  autoComplete?: string;
   className?: string;
   containerStyle?: Object;
   disabledStyle?: Object;


### PR DESCRIPTION
- **What does this PR do?**

Adds `id` and `autoComplete` props that are passed down to inputs. Changes are backwards compatible and won't break current implementations.

`id` allows proper use of form labels

`autoComplete` allows optimization for various environments: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#sect16

- **Screenshots and/or Live Demo**

![react_otp_input_label](https://user-images.githubusercontent.com/2466445/159067075-5e84d91b-0907-4b3b-9062-3722a48f5c68.gif)
