### PR TITLE
fix(305): added removing non-digits if needed

### DIFF
--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -201,10 +201,11 @@ class OtpInput extends Component {
     let nextActiveInput = activeInput;
 
     // Get pastedData in an array of max size (num of inputs - current position)
-    const pastedData = e.clipboardData
-      .getData('text/plain')
-      .slice(0, numInputs - activeInput)
-      .split('');
+    const rawPastedData = e.clipboardData.getData('text/plain');
+
+    const filteredData = this.props.isInputNum ? rawPastedData.replace(/\D/g, '') : rawPastedData;
+
+    const pastedData = filteredData.slice(0, numInputs - activeInput).split('');
 
     // Paste data from focused input onwards
     for (let pos = 0; pos < numInputs; ++pos) {


### PR DESCRIPTION
- **What does this PR do?**
When `isInputNum` and user ctrl + v string with non-digits, then those digits filters from non-digits.

- **Any background context you want to provide?**
You can try set `isInputNum` true and try paste for example `abc1234` and you will see what the bug is

- **Screenshots and/or Live Demo**
Live demo https://monosnap.com/file/PzMs5VjsJEEwKmYfYCc3bJLOmC6btF