### PR TITLE
fix: android backspace not working

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -125,7 +125,7 @@ const OTPInput = ({
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     const otp = getOTPValue();
-    if (event.code === 'Backspace') {
+    if ([event.code, event.key].includes('Backspace')) {
       event.preventDefault();
       changeCodeAtFocus('');
       focusInput(activeInput - 1);


### PR DESCRIPTION
- **What does this PR do?**
Fixes #388 

- **Any background context you want to provide?**
In android, event.code has no value if user click backspace. However, event.key has "backspace" value so instead of just checking event.code, event.key also must be checked.

- **Screenshots and/or Live Demo** 
![Screenshot 2023-03-26 at 12 17 32](https://user-images.githubusercontent.com/50797736/227766641-7f9862ae-ebfc-47df-aeda-e0b41609b65b.png)

