### PR TITLE
add: new boolean type prop to consider or not consider spaces as valid characters in OTP input

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ export default function App() {
     <td>false</td>
     <td>Auto focuses input on initial page load.</td>
   </tr>
+  <tr>
+    <td>shouldRemoveWhiteSpaceOnPaste</td>
+    <td>boolean</td>
+    <td>false</td>
+    <td>false</td>
+    <td>Removes white spaces from pasted OTP characters.</td>
+  </tr>
 </table>
 
 ### ⚠️ Warning
@@ -151,6 +158,8 @@ The v3 of `react-otp-input` is a complete rewrite of the library. Apart from mak
 - The `separator` prop has now been renamed to `renderSeparator`. This prop now apart from accepting a component that will be rendered as a separator between inputs like it used to, now also accepts a function that returns a component. The function will get the index of the separator being rendered as an argument.
 
 - A new prop called `inputType` has been added to the component. This prop can be used to specify the type of the input that will be passed to the input element being rendered. The default value of this prop is `number`.
+
+- An new prop called `shouldRemoveWhiteSpaceOnPaste` has been added to the component. This prop can be used to disallow spaces as valid OTP characters. This is default set to `false`.
 
 ## Migrating from v1
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -116,6 +116,7 @@ function App() {
                 inputType={inputType}
                 renderInput={(props) => <input {...props} />}
                 shouldAutoFocus
+                shouldRemoveWhiteSpaceOnPaste
               />
             </div>
             <div className="btn-row">

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -44,7 +44,7 @@ interface OTPInputProps {
   inputStyle?: React.CSSProperties | string;
   /** The type that will be passed to the input being rendered */
   inputType?: AllowedInputTypes;
-  /** Boolean to consider spaces as valid OTP values */
+  /** Boolean to not consider spaces as valid OTP values */
   shouldRemoveWhiteSpaceOnPaste?: boolean;
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -44,6 +44,8 @@ interface OTPInputProps {
   inputStyle?: React.CSSProperties | string;
   /** The type that will be passed to the input being rendered */
   inputType?: AllowedInputTypes;
+  /** Boolean to consider spaces as valid OTP values */
+  shouldRemoveWhiteSpaceOnPaste?: boolean;
 }
 
 const isStyleObject = (obj: unknown) => typeof obj === 'object' && obj !== null;
@@ -59,6 +61,7 @@ const OTPInput = ({
   placeholder,
   containerStyle,
   inputStyle,
+  shouldRemoveWhiteSpaceOnPaste = false,
 }: OTPInputProps) => {
   const [activeInput, setActiveInput] = React.useState(0);
   const inputRefs = React.useRef<Array<HTMLInputElement | null>>([]);
@@ -184,10 +187,14 @@ const OTPInput = ({
     let nextActiveInput = activeInput;
 
     // Get pastedData in an array of max size (num of inputs - current position)
-    const pastedData = event.clipboardData
+    let pastedData = event.clipboardData
       .getData('text/plain')
       .slice(0, numInputs - activeInput)
       .split('');
+
+    if(shouldRemoveWhiteSpaceOnPaste) {
+      pastedData = pastedData.filter((character) => character !== ' ');
+    }
 
     // Prevent pasting if the clipboard data contains non-numeric values for number inputs
     if (isInputNum && pastedData.some((value) => isNaN(Number(value)))) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -186,15 +186,16 @@ const OTPInput = ({
     const otp = getOTPValue();
     let nextActiveInput = activeInput;
 
+    let pastedString = event.clipboardData.getData('text/plain');
+
+    if (shouldRemoveWhiteSpaceOnPaste) {
+      pastedString = pastedString.replace(/\s/g, '');
+    }
+
     // Get pastedData in an array of max size (num of inputs - current position)
-    let pastedData = event.clipboardData
-      .getData('text/plain')
+    const pastedData = pastedString
       .slice(0, numInputs - activeInput)
       .split('');
-
-    if(shouldRemoveWhiteSpaceOnPaste) {
-      pastedData = pastedData.filter((character) => character !== ' ');
-    }
 
     // Prevent pasting if the clipboard data contains non-numeric values for number inputs
     if (isInputNum && pastedData.some((value) => isNaN(Number(value)))) {


### PR DESCRIPTION
- **What does this PR do?**
The PR adds a new prop to toggle if the white space in copied value should be considered a valid character on paste operation.

- **Any background context you want to provide?**
Adds functionality for [this](https://github.com/devfolioco/react-otp-input/issues/382) requested feature.
