### PR TITLE
fix: paste from clipboard doesn't work on desktop

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -151,7 +151,7 @@ const OTPInput = ({
       event.code === 'ArrowDown'
     ) {
       event.preventDefault();
-    } else if (isInputNum && !isInputValueValid(event.key)) {
+    } else if (isInputNum && !isInputValueValid(event.key) && event.code !== 'KeyV' && event.code !== 'Insert') {
       event.preventDefault();
     }
   };


### PR DESCRIPTION
(add) added a condition to the check for inputType number.

<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
Paste from clipboard returned to work if inputType number on desktop.

- **Any background context you want to provide?**
When the `handleKeyDown` function checks for keys pressed from the keyboard, the condition for inputType number validated the values, and _ControlLeft_ and _V_ returned false when validated in the `isInputValueValid` function, which combined with the negation of the boolean triggered `event.preventDefault`, and the `handlePaste` function was not even called. I added a condition that ignored the last _V_ and _Insert_, which does not block further execution of the event, and the `handlePaste` method is called correctly when _Ctrl + V_ and _Shift + Insert_ are combined. I suspect that my solution might not look elegant enough, but combined with the checks elsewhere, _V_ and _Insert_ can't get into Input in this case.
