### PR TITLE
Support onPaste event handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ export default function App() {
     </br></br>
     Example:
     <pre>
-const handlePaste: ClipboardEventHandler<HTMLDivElement> = (event) => {
+const handlePaste: React.ClipboardEventHandler<HTMLDivElement> = (event) => {
   const data = event.clipboardData.getData('text');
   console.log(data)
 };</pre>

--- a/README.md
+++ b/README.md
@@ -81,6 +81,24 @@ export default function App() {
     <td>Returns OTP code typed in inputs.</td>
   </tr>
   <tr>
+    <td>onPaste</td>
+    <td>function</td>
+    <td>false</td>
+    <td>none</td>
+    <td>Provide a custom onPaste event handler scoped to the OTP inputs container. Executes when content is pasted into any OTP field.
+    </br></br>
+    Example:
+    <pre>
+const handlePaste = (event) => {
+  const data = event.clipboardData.getData('text');
+  console.log(data)
+};</pre>
+
+  > Note: The function type for Typescript is: `ClipboardEventHandler<HTMLDivElement>`
+
+  </td>
+  </tr>
+  <tr>
     <td>value</td>
     <td>string / number</td>
     <td>true</td>

--- a/README.md
+++ b/README.md
@@ -89,12 +89,10 @@ export default function App() {
     </br></br>
     Example:
     <pre>
-const handlePaste = (event) => {
+const handlePaste: ClipboardEventHandler<HTMLDivElement> = (event) => {
   const data = event.clipboardData.getData('text');
   console.log(data)
 };</pre>
-
-  > Note: The function type for Typescript is: `ClipboardEventHandler<HTMLDivElement>`
 
   </td>
   </tr>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,6 +32,8 @@ interface OTPInputProps {
   numInputs?: number;
   /** Callback to be called when the OTP value changes */
   onChange: (otp: string) => void;
+  /** Callback to be called when pasting content into the component */
+  onPaste?: () => void;
   /** Function to render the input */
   renderInput: (inputProps: InputProps, index: number) => React.ReactNode;
   /** Whether the first input should be auto focused */
@@ -54,6 +56,7 @@ const OTPInput = ({
   value = '',
   numInputs = 4,
   onChange,
+  onPaste,
   renderInput,
   shouldAutoFocus = false,
   inputType = 'text',
@@ -217,6 +220,7 @@ const OTPInput = ({
     <div
       style={Object.assign({ display: 'flex', alignItems: 'center' }, isStyleObject(containerStyle) && containerStyle)}
       className={typeof containerStyle === 'string' ? containerStyle : undefined}
+      onPaste={onPaste}
     >
       {Array.from({ length: numInputs }, (_, index) => index).map((index) => (
         <React.Fragment key={index}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,7 +33,7 @@ interface OTPInputProps {
   /** Callback to be called when the OTP value changes */
   onChange: (otp: string) => void;
   /** Callback to be called when pasting content into the component */
-  onPaste?: () => void;
+  onPaste?: (event: ClipboardEvent) => void;
   /** Function to render the input */
   renderInput: (inputProps: InputProps, index: number) => React.ReactNode;
   /** Whether the first input should be auto focused */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,7 +33,7 @@ interface OTPInputProps {
   /** Callback to be called when the OTP value changes */
   onChange: (otp: string) => void;
   /** Callback to be called when pasting content into the component */
-  onPaste?: (event: ClipboardEvent) => void;
+  onPaste?: (event: React.ClipboardEvent<HTMLDivElement>) => void;
   /** Function to render the input */
   renderInput: (inputProps: InputProps, index: number) => React.ReactNode;
   /** Whether the first input should be auto focused */


### PR DESCRIPTION
- **What does this PR do?**
Adds the ability to pass in an "onPaste" handler to the wrapper component to handle content getting pasted into the input fields.

- **Any background context you want to provide?**
We needed this functionality. Our solution was to wrap `OTPInput` in a `div` that did this but thought it might be useful to others if the component just supported it.
