### PR TITLE
feat: add `onBlur` and `onFocus` callback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ A fully customizable, one-time password input component for the web built with R
 ![see here](https://media.giphy.com/media/lN98dFU6h3oP0wWS5x/giphy.gif)
 
 [Live Demo](https://devfolioco.github.io/react-otp-input)
-<!-- 
+
+<!--
 [CodeSandbox](https://codesandbox.io/s/react-otp-input-demo-v2-1iy52) -->
 
 ## Installation
@@ -24,6 +25,7 @@ npm install --save react-otp-input
 ```
 
 ### Still using v2?
+
 No problem! You can find the documentation for v2 [here](https://github.com/devfolioco/react-otp-input/tree/v2.4.0)
 
 #### Basic usage:
@@ -74,6 +76,13 @@ export default function App() {
     </td>
   </tr>
   <tr>
+    <td>onFocus</td>
+    <td>function</td>
+    <td>false</td>
+    <td>none</td>
+    <td>Called when OTP has received focus. The <code>index</code> of the input gaining focus is passed as the first argument</td>
+  </tr>
+  <tr>
     <td>onChange</td>
     <td>function</td>
     <td>true</td>
@@ -95,6 +104,13 @@ const handlePaste: React.ClipboardEventHandler<HTMLDivElement> = (event) => {
 };</pre>
 
   </td>
+  </tr>
+  <tr>
+    <td>onBlur</td>
+    <td>function</td>
+    <td>false</td>
+    <td>none</td>
+    <td>Called when OTP has lost focus.</td>
   </tr>
   <tr>
     <td>value</td>
@@ -155,7 +171,9 @@ const handlePaste: React.ClipboardEventHandler<HTMLDivElement> = (event) => {
 </table>
 
 ### ⚠️ Warning
+
 Do not override the following props on the input component that you return from the `renderInput` prop. Doing so might lead to unexpected behaviour.
+
 - `ref`
 - `value`
 - `onChange`

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -110,7 +110,9 @@ function App() {
               <OTPInput
                 inputStyle="inputStyle"
                 numInputs={numInputs}
+                onFocus={(index) => console.log(`OTP: Input #${index + 1} has gained focus!`)}
                 onChange={handleOTPChange}
+                onBlur={(index) => console.log(`OTP: Input #${index + 1} has lost focus!`)}
                 renderSeparator={<span>{separator}</span>}
                 value={otp}
                 placeholder={placeholder}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,10 +29,14 @@ interface OTPInputProps {
   value?: string;
   /** Number of OTP inputs to be rendered */
   numInputs?: number;
+  /** Callback to be called when the OTP has received focued */
+  onFocus?: (index: number) => void;
   /** Callback to be called when the OTP value changes */
   onChange: (otp: string) => void;
   /** Callback to be called when pasting content into the component */
   onPaste?: (event: React.ClipboardEvent<HTMLDivElement>) => void;
+  /** Callback to be called when the OTP has lost focus */
+  onBlur?: (index: number) => void;
   /** Function to render the input */
   renderInput: (inputProps: InputProps, index: number) => React.ReactNode;
   /** Whether the first input should be auto focused */
@@ -56,8 +60,10 @@ const isStyleObject = (obj: unknown) => typeof obj === 'object' && obj !== null;
 const OTPInput = ({
   value = '',
   numInputs = 4,
+  onFocus,
   onChange,
   onPaste,
+  onBlur,
   renderInput,
   shouldAutoFocus = false,
   inputType = 'text',
@@ -145,10 +151,17 @@ const OTPInput = ({
   const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => (index: number) => {
     setActiveInput(index);
     event.target.select();
+
+    if (!inputRefs.current.includes(event.relatedTarget as HTMLInputElement)) {
+      onFocus?.(index);
+    }
   };
 
-  const handleBlur = () => {
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => (index: number) => {
     setActiveInput(activeInput - 1);
+    if (!inputRefs.current.includes(event.relatedTarget as HTMLInputElement)) {
+      onBlur?.(index);
+    }
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -247,7 +260,7 @@ const OTPInput = ({
               ref: (element) => (inputRefs.current[index] = element),
               onChange: handleChange,
               onFocus: (event) => handleFocus(event)(index),
-              onBlur: handleBlur,
+              onBlur: (event) => handleBlur(event)(index),
               onKeyDown: handleKeyDown,
               onPaste: handlePaste,
               autoComplete: 'off',


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
Fixes #17 

- **Any background context you want to provide?**
We're basically adding support for `blur` or `focus` callbacks

- **Screenshots and/or Live Demo**
See console in the `example` sandbox:

https://github.com/devfolioco/react-otp-input/assets/20970325/2408b75d-906d-45d7-9cf8-8cf079f5c86f

