### PR TITLE
Fix/Autocomplete issue has been fixed

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -250,7 +250,7 @@ const OTPInput = ({
               onBlur: handleBlur,
               onKeyDown: handleKeyDown,
               onPaste: handlePaste,
-              autoComplete: 'off',
+              autoComplete: 'one-time-code',
               'aria-label': `Please enter OTP character ${index + 1}`,
               style: Object.assign(
                 !skipDefaultStyles ? ({ width: '1em', textAlign: 'center' } as const) : {},


### PR DESCRIPTION

- **What does this PR do?**
- It resolves the issue with OTP autocompletion.

- **Any background context you want to provide?**
-  Imagine a scenario where we've integrated this library into mobile devices. When a user receives an OTP on their device, the code appears on the keyboard for autocompletion instead of manual typing. However, clicking on the OTP previously only completed one digit. With this PR, I've updated the autoComplete field value from 'off' to 'one-time-code'. Now, users have the option to autofill the entire OTP once it's received.
- 
