### PR TITLE
Fix input focus issue in react-otp-input

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -70,7 +70,7 @@ const OTPInput = ({
   const [activeInput, setActiveInput] = React.useState(0);
   const inputRefs = React.useRef<Array<HTMLInputElement | null>>([]);
 
-  const getOTPValue = () => (value ? value.toString().split('') : []);
+  const getOTPValue = () => (value ? value.toString().split('') : Array(numInputs).fill(' '));
 
   const isInputNum = inputType === 'number' || inputType === 'tel';
 


### PR DESCRIPTION


<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
Resolved the issue where entering a value in a focused input box would incorrectly fill the previous empty input boxes. Now the value is correctly filled in the currently focused input field.

- **Any background context you want to provide?**

- **Screenshots and/or Live Demo**
Issue - 
![chrome-capture-2024-3-12](https://github.com/devfolioco/react-otp-input/assets/27428809/6f35c43c-0ce5-45ce-8fad-f8908faaa0ac)

Fix -
![chrome-capture-2024-3-12 (1)](https://github.com/devfolioco/react-otp-input/assets/27428809/c258147b-1db7-4561-ad73-0c201d868993)


