### PR TITLE
fix: Values always added from first input even when another input is selected or focused

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -129,6 +129,7 @@ const OTPInput = ({
         if (!hasInvalidInput) {
           handleOTPChange(value.split(''));
           focusInput(numInputs - 1);
+          otpValueRef.current = valueArr;
         }
       }
 


### PR DESCRIPTION
Replaced the  ``` const getOTPValue = () => (value ? value.toString().split('') : []);```  function with ```useRef``` hook to save the state of the current otp array to match each input box with its index of the array to fix the issue of when adding new value it always starts from the first input box even when another input is selected or focused.

Also, add an if check to check at each rerender if the value is empty string then reset the value of the otp array.

```
if (value.trim() === '') {
    otpValueRef.current = Array(numInputs);
  }
```

Moreover, removed the activeInput subtract from numInputs in  
``` 
const pastedData = event.clipboardData
      .getData('text/plain')
      .slice(0, numInputs - activeInput)
      .split('');
``` 
and removed the check for pos >= activeInput in 
 ```
if (pos >= activeInput && pastedData.length > 0) {
        otp[pos] = pastedData.shift() ?? '';
```
to make pasting start from the first input even if any other input is selected or focused

PS: I don't know if the copy paste behavior for always starting from the first input is intended or not but I felt that it make sense to paste the whole copied string across all the input not just starting from selected one.
